### PR TITLE
Fix crowbar applying breakable glass decals to unbreakable pushable objects

### DIFF
--- a/dlls/func_break.cpp
+++ b/dlls/func_break.cpp
@@ -818,6 +818,8 @@ public:
 	// breakables use an overridden takedamage
 	bool TakeDamage(entvars_t* pevInflictor, entvars_t* pevAttacker, float flDamage, int bitsDamageType) override;
 
+	int DamageDecal(int bitsDamageType) override;
+
 	static TYPEDESCRIPTION m_SaveData[];
 
 	static const char* m_soundNames[3];
@@ -1022,4 +1024,12 @@ bool CPushable::TakeDamage(entvars_t* pevInflictor, entvars_t* pevAttacker, floa
 		return CBreakable::TakeDamage(pevInflictor, pevAttacker, flDamage, bitsDamageType);
 
 	return true;
+}
+
+int CPushable::DamageDecal(int bitsDamageType)
+{
+	if (FBitSet(pev->spawnflags, SF_PUSH_BREAKABLE))
+		return CBreakable::DamageDecal(bitsDamageType);
+
+	return CBaseEntity::DamageDecal(bitsDamageType);
 }


### PR DESCRIPTION
Can be seen on push-able boxes in `c1a2`, where the headcrabs drop from the breakable ceiling panels.