### PR TITLE
Fix weapon events not treating pushable objects as BSP models

### DIFF
--- a/cl_dll/ev_hldm.cpp
+++ b/cl_dll/ev_hldm.cpp
@@ -52,6 +52,12 @@ void V_PunchAxis(int axis, float punch);
 void VectorAngles(const float* forward, float* angles);
 
 extern cvar_t* cl_lw;
+extern cvar_t* r_decals;
+
+static inline bool EV_HLDM_IsBSPModel(physent_t* pe)
+{
+	return pe != nullptr && (pe->solid == SOLID_BSP || pe->movetype == MOVETYPE_PUSHSTEP);
+}
 
 // play a strike sound based on the texture that was hit by the attack traceline.  VecSrc/VecEnd are the
 // original traceline endpoints used by the attacker, iBulletType is the type of bullet that hit the texture.
@@ -209,6 +215,9 @@ char* EV_HLDM_DamageDecal(physent_t* pe)
 	static char decalname[32];
 	int idx;
 
+	if (pe->rendermode == kRenderTransAlpha)
+		return nullptr;
+
 	if (pe->classnumber == 1)
 	{
 		idx = gEngfuncs.pfnRandomLong(0, 2);
@@ -229,7 +238,6 @@ char* EV_HLDM_DamageDecal(physent_t* pe)
 void EV_HLDM_GunshotDecalTrace(pmtrace_t* pTrace, char* decalName)
 {
 	int iRand;
-	physent_t* pe;
 
 	gEngfuncs.pEfxAPI->R_BulletImpactParticles(pTrace->endpos);
 
@@ -256,17 +264,12 @@ void EV_HLDM_GunshotDecalTrace(pmtrace_t* pTrace, char* decalName)
 		}
 	}
 
-	pe = gEngfuncs.pEventAPI->EV_GetPhysent(pTrace->ent);
-
 	// Only decal brush models such as the world etc.
-	if (decalName && '\0' != decalName[0] && pe && (pe->solid == SOLID_BSP || pe->movetype == MOVETYPE_PUSHSTEP))
+	if (decalName && '\0' != decalName[0] && r_decals->value > 0)
 	{
-		if (CVAR_GET_FLOAT("r_decals"))
-		{
-			gEngfuncs.pEfxAPI->R_DecalShoot(
-				gEngfuncs.pEfxAPI->Draw_DecalIndex(gEngfuncs.pEfxAPI->Draw_DecalIndexFromName(decalName)),
-				gEngfuncs.pEventAPI->EV_IndexFromTrace(pTrace), 0, pTrace->endpos, 0);
-		}
+		gEngfuncs.pEfxAPI->R_DecalShoot(
+			gEngfuncs.pEfxAPI->Draw_DecalIndex(gEngfuncs.pEfxAPI->Draw_DecalIndexFromName(decalName)),
+			gEngfuncs.pEventAPI->EV_IndexFromTrace(pTrace), 0, pTrace->endpos, 0);
 	}
 }
 
@@ -276,7 +279,7 @@ void EV_HLDM_DecalGunshot(pmtrace_t* pTrace, int iBulletType)
 
 	pe = gEngfuncs.pEventAPI->EV_GetPhysent(pTrace->ent);
 
-	if (pe && pe->solid == SOLID_BSP)
+	if (EV_HLDM_IsBSPModel(pe))
 	{
 		switch (iBulletType)
 		{
@@ -926,7 +929,7 @@ void EV_FireGauss(event_args_t* args)
 		if (pEntity == NULL)
 			break;
 
-		if (pEntity->solid == SOLID_BSP)
+		if (EV_HLDM_IsBSPModel(pEntity))
 		{
 			float n;
 
@@ -1177,7 +1180,7 @@ void EV_FireCrossbow2(event_args_t* args)
 		physent_t* pe = gEngfuncs.pEventAPI->EV_GetPhysent(tr.ent);
 
 		//Not the world, let's assume we hit something organic ( dog, cat, uncle joe, etc ).
-		if (pe->solid != SOLID_BSP)
+		if (!EV_HLDM_IsBSPModel(pe))
 		{
 			switch (gEngfuncs.pfnRandomLong(0, 1))
 			{

--- a/cl_dll/hud.cpp
+++ b/cl_dll/hud.cpp
@@ -85,6 +85,7 @@ cvar_t* cl_lw = NULL;
 cvar_t* cl_rollangle = nullptr;
 cvar_t* cl_rollspeed = nullptr;
 cvar_t* cl_bobtilt = nullptr;
+cvar_t* r_decals = nullptr;
 
 void ShutdownInput();
 
@@ -334,6 +335,7 @@ void CHud::Init()
 	cl_rollangle = CVAR_CREATE("cl_rollangle", "2.0", FCVAR_ARCHIVE);
 	cl_rollspeed = CVAR_CREATE("cl_rollspeed", "200", FCVAR_ARCHIVE);
 	cl_bobtilt = CVAR_CREATE("cl_bobtilt", "0", FCVAR_ARCHIVE);
+	r_decals = gEngfuncs.pfnGetCvarPointer("r_decals");
 
 	m_pSpriteList = NULL;
 


### PR DESCRIPTION
Fixes bullet decals not being applied and Gauss Gun shots not being visibly reflected. Also, in `EV_HLDM_GunshotDecalTrace`, the call to `CVAR_GET_FLOAT` is replaced with a pointer to `r_decals`, since the function gets called frequently.