### PR TITLE
Fix anglemod function in pm_math.cpp

### DIFF
--- a/pm_shared/pm_math.cpp
+++ b/pm_shared/pm_math.cpp
@@ -31,7 +31,7 @@ int nanmask = 255 << 23;
 
 float anglemod(float a)
 {
-	a = (360.0 / 65536) * ((int)(a * (65536 / 360.0)) & 65535);
+	a = static_cast<float>(360.0f / 65536) * (static_cast<int>(a * static_cast<float>(65536 / 360.0f)) & 65535);
 	return a;
 }
 


### PR DESCRIPTION
When compiled with GCC, the result of anglemod is incorrect, probably due to the way `(360.0 / 65536)` and `(65536 / 360.0)` are pre-calculated when using the C++17 standard. 

This results in the yaw of the viewmodel being incorrectly rotated. 

https://github.com/SamVanheer/halflife-updated/assets/32138106/7eca5aea-29c4-47c1-a611-200f3ebe97e1

By explicitly typecasting, the problem can be avoided. 