### PR TITLE
client: fix NULL dereference and mouse issues on Linux

### DIFF
--- a/cl_dll/inputw32.cpp
+++ b/cl_dll/inputw32.cpp
@@ -67,7 +67,9 @@ static cvar_t* m_rawinput = nullptr;
 
 static bool IN_UseRawInput()
 {
-	return m_rawinput->value != 0;
+	// a1ba: m_rawinput 1 is SDL input on Windows
+	// Linux only has SDL input, so return true here
+	return m_rawinput ? m_rawinput->value != 0 : true;
 }
 
 static SDL_bool mouseRelative = SDL_TRUE;
@@ -268,11 +270,7 @@ void DLLEXPORT IN_ActivateMouse()
 		mouseactive = true;
 	}
 
-	if (g_iVisibleMouse
-#ifdef WIN32
-		|| !IN_UseRawInput()
-#endif
-	)
+	if (g_iVisibleMouse || !IN_UseRawInput())
 	{
 		IN_SetMouseRelative(false);
 	}
@@ -635,7 +633,6 @@ void IN_MouseMove(float frametime, usercmd_t* cmd)
 
 	gEngfuncs.SetViewAngles((float*)viewangles);
 
-#ifdef WIN32
 	if ((!IN_UseRawInput() && SDL_FALSE != mouseRelative) || g_iVisibleMouse)
 	{
 		IN_SetMouseRelative(false);
@@ -644,7 +641,6 @@ void IN_MouseMove(float frametime, usercmd_t* cmd)
 	{
 		IN_SetMouseRelative(true);
 	}
-#endif
 
 	/*
 //#define TRACE_TEST


### PR DESCRIPTION
m_rawinput is nullptr on Linux, so add NULL check there.

The relative state wasn't restored correctly on Linux, so this fixes cursor visibility issue (SDL doesn't show cursor with relative mode enabled) and mouse being locked by window bounds.