### PR TITLE
Initialized flvol variable

### DIFF
--- a/cl_dll/geiger.cpp
+++ b/cl_dll/geiger.cpp
@@ -64,7 +64,7 @@ bool CHudGeiger::MsgFunc_Geiger(const char* pszName, int iSize, void* pbuf)
 bool CHudGeiger::Draw(float flTime)
 {
 	int pct;
-	float flvol;
+	float flvol = 0.0;
 	int rg[3];
 	int i;
 


### PR DESCRIPTION
The uninitialized variable would cause a debug pop-up to appear when near radioactive material.
![Screenshot 2024-10-29 213012](https://github.com/user-attachments/assets/e420fc25-c93f-4047-89ab-d91543635f4a)
